### PR TITLE
背手文件

### DIFF
--- a/KeyFrameArms.h
+++ b/KeyFrameArms.h
@@ -1,0 +1,108 @@
+
+option(KeyFrameArms, (ArmKeyFrameRequest::ArmKeyFrameId) motion, (bool) (false) fast)
+{
+   // (ArmKeyFrameRequest::ArmKeyFrameId)(ArmKeyFrameRequest::useDefault) motion
+    
+    
+  initial_state(setRequest)
+  {
+    transition
+    {
+   //   if(theArmMotionSelection.targetArmMotion[Arms::left] == ArmMotionRequest::keyFrame
+ //&& theArmKeyFrameEngineOutput.arms[Arms::left].motion == motion &&
+     // theArmMotionSelection.targetArmMotion[Arms::right] == ArmMotionRequest::keyFrame
+ //&& theArmKeyFrameEngineOutput.arms[Arms::right].motion == motion)
+      goto requestIsExecuted;
+       
+    }
+    action
+    {
+      //KeyFrameLeftArm(motion, fast);
+     // KeyFrameRightArm(motion, fast);
+    }
+  }
+
+  target_state(requestIsExecuted)
+  {
+    transition
+    {
+     // if(!(theArmMotionSelection.targetArmMotion[Arms::left] == ArmMotionRequest::keyFrame) || theArmKeyFrameEngineOutput.arms[Arms::left].motion != motion ||
+    //  !(theArmMotionSelection.targetArmMotion[Arms::right] == ArmMotionRequest::keyFrame) || theArmKeyFrameEngineOutput.arms[Arms::right].motion != motion)
+     // goto setRequest;
+    }
+    action
+    {
+      KeyFrameLeftArm(motion, fast);
+      KeyFrameRightArm(motion, fast);
+    }
+  }
+}
+ 
+
+
+option(KeyFrameLeftArm, (ArmKeyFrameRequest::ArmKeyFrameId) motion, (bool)(false) fast)
+{
+  initial_state(setRequest)
+  {
+    transition
+    {
+      //if(theArmMotionSelection.targetArmMotion[Arms::left] == ArmMotionRequest::keyFrame && theArmKeyFrameEngineOutput.arms[Arms::left].motion == motion)
+        goto requestIsExecuted;
+    }
+    action
+    {
+      theArmMotionRequest.armMotion[Arms::left] = ArmMotionRequest::keyFrame;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::left].motion = motion;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::left].fast = fast;
+    }
+  }
+
+  target_state(requestIsExecuted)
+  {
+    transition
+    {
+     // if(!(theArmMotionSelection.targetArmMotion[Arms::left] == ArmMotionRequest::keyFrame) || theArmKeyFrameEngineOutput.arms[Arms::left].motion != motion)
+        goto setRequest;
+    }
+    action
+    {
+      theArmMotionRequest.armMotion[Arms::left] = ArmMotionRequest::keyFrame;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::left].motion = motion;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::left].fast = fast;
+    }
+  }
+}
+
+ 
+option(KeyFrameRightArm, (ArmKeyFrameRequest::ArmKeyFrameId) motion, (bool) (false) fast)
+{
+  initial_state(setRequest)
+  {
+    transition
+    {
+     // if(theArmMotionSelection.targetArmMotion[Arms::right] == ArmMotionRequest::keyFrame && theArmKeyFrameEngineOutput.arms[Arms::right].motion == motion)
+        goto requestIsExecuted;
+    }
+    action
+    {
+      theArmMotionRequest.armMotion[Arms::right] = ArmMotionRequest::keyFrame;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].motion = motion;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].fast = fast;
+    }
+  }
+
+  target_state(requestIsExecuted)
+  {
+    transition
+    {
+      //if(!(theArmMotionSelection.targetArmMotion[Arms::right] == ArmMotionRequest::keyFrame) || theArmKeyFrameEngineOutput.arms[Arms::right].motion != motion)
+       // goto setRequest;
+    }
+    action
+    {
+      theArmMotionRequest.armMotion[Arms::right] = ArmMotionRequest::keyFrame;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].motion = motion;
+      theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].fast = fast;
+    }
+  }
+}


### PR DESCRIPTION
方法一 直接调用
把下面三行加到需要进行背手的state中
theArmMotionRequest.armMotion[Arms::right]=ArmMotionRequest::keyFrame; theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].motion=ArmKeyFrameRequest::back;   theArmMotionRequest.armKeyFrameRequest.arms[Arms::right].fast = true;
Right和left是选择执行背手动作的手
第三行true表示快速执行

方法二 使用函数KeyFrameArms（相当于把方法一写成函数）
把提供的KeyFrameArms.h加到文件中，推荐加到OUTPUT文件夹下，然后在option中加入头文件，即可使用。
调用方法，双手/单手，true可以不加，默认为true。